### PR TITLE
add parent param to community create

### DIFF
--- a/lib/dspace/client/resources/communities.rb
+++ b/lib/dspace/client/resources/communities.rb
@@ -13,8 +13,12 @@ module DSpace
       DSpace::List.from_response(client, response, key: "communities", type: DSpace::Community)
     end
 
-    def create(**attributes)
-      DSpace::Community.new client, post_request(body: attributes).body
+    def create(parent: nil, **attributes)
+      if parent
+        DSpace::Community.new client, post_request(body: attributes, params: { parent: parent }).body
+      else
+        DSpace::Community.new client, post_request(body: attributes).body
+      end
     end
 
     def retrieve(uuid:)


### PR DESCRIPTION
This PR enhances the `create` method under community to allow for creating a child community under a parent community. It is structured similarly to the `create` method under collection.