### PR TITLE
Update communities crud example

### DIFF
--- a/examples/communities_crud.rb
+++ b/examples/communities_crud.rb
@@ -25,7 +25,9 @@ body = {
     ]
   }
 }
-community = client.communities.search_by_metadata(body[:name]).data.first
+search = client.communities.search_by_metadata("\"#{body[:name]}\"")
+raise "Expected zero or one community :(" if search.total_elements > 1
+community = search.data.first
 if community&.uuid
   puts "Community already exists"
 else


### PR DESCRIPTION
Strictly speaking examples aren't intended to be "runnable" at all
times. They're just examples. But this update shows a more precise
way of looking for a single community.

Resolves #8
